### PR TITLE
pequena correção dos retornos nos exemplos de closures

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -394,14 +394,14 @@ incrementador(1);
 Também podemos definir o tipo do retorno:
 
 ```rust
-let incrementador = | x :i32 -> i32 | x + 1;
+let incrementador = | x :i32 | -> i32 { x + 1 };
 incrementador(1);
 ```
 
 Para uma visão mais clara, isso pode acontecer como um exemplo de função completa, com regras complexas e quebra de linha:
 
 ```rust
-let incrementador = | x :i32 -> i32 | {
+let incrementador = | x :i32 | -> i32 {
     let valor_incremento :i32 = 1;
     let valor_incrementado :i32 = x + valor_incremento;
     return valor_incrementado


### PR DESCRIPTION
Só uma pequena correção, até pensei se não era algo da edição de 2018 (edição dos exercícios que tem no repo), mas pela documentação (da edição de 2018) pude ver os exemplos e confirmei. De qualquer forma ta me ajudando bastante, Obg.